### PR TITLE
fixed a typo error on index page on charts endpoint

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -627,7 +627,7 @@ This endpoint retrieves trade history HOLCV for all pairs.
 
 ### HTTP Request
 
-`GET https://api.hollaex.com/v2/charts?resolution=${resolution}&from=${from}to=${to}`
+`GET https://api.hollaex.com/v2/charts?resolution=${resolution}&from=${from}&to=${to}`
 
 ### PARAMETERS
 


### PR DESCRIPTION
On charts endpoint an "&" mark before "to" parameter was lost and on this commit I've add it.